### PR TITLE
Raise a SchemaError when a RecordSchema is missing a fields array

### DIFF
--- a/lib/tros/schema.rb
+++ b/lib/tros/schema.rb
@@ -204,6 +204,8 @@ module Tros
       attr_reader :fields
 
       def self.make_field_objects(field_data, names, namespace=nil)
+        raise SchemaParseError, "Record Schema requires a fields array" if field_data.nil?
+
         field_objects, field_names = [], Set.new
         field_data.each_with_index do |field, i|
           if field.respond_to?(:[]) # TODO(jmhodges) wtffffff


### PR DESCRIPTION
It used to raise a NoMethodError with the following message "undefined method `each_with_index' for nil:NilClass"
when it was presented with a SchemaRecord that didn't include a fields array.

This PR makes the SchemaRecord raise a readable SchemaParseError instead. I couldn't find any specs regarding schema parsing and parse errors so I could only test this manually.
