### PR TITLE
Support Enum Fields with Default values

### DIFF
--- a/lib/tros/io.rb
+++ b/lib/tros/io.rb
@@ -600,7 +600,7 @@ module Tros
 
       def write_record(writers_schema, datum, encoder)
         writers_schema.fields.each do |field|
-          write_data(field.type, datum[field.name], encoder)
+          write_data(field.type, (if datum[field.name].nil? then field.default else datum[field.name] end), encoder)
         end
       end
     end # DatumWriter

--- a/lib/tros/schema.rb
+++ b/lib/tros/schema.rb
@@ -131,7 +131,7 @@ module Tros
         expected_schema.schemas.any? { |s| send(validator_method, s, datum) }
       when :record, :error, :request
         datum.is_a?(Hash) &&
-          expected_schema.fields.all? { |f| send(validator_method, f.type, datum[f.name]) }
+          expected_schema.fields.all? { |f| send(validator_method, f.type, (if datum[f.name].nil? then f.default else datum[f.name] end)) }
       else
         raise TypeError, "#{expected_schema.inspect} is not recognized as type."
       end


### PR DESCRIPTION
As of Avro 1.9, Enum types can have a default value.